### PR TITLE
ci(dependabot): ignore nx dependencies for auto update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    ignore:
+      # Use migrations to update @nrwl/* updates.
+      # Run `yarn nx migrate latest` instead
+      - name: '@nrwl/*'


### PR DESCRIPTION
use `yarn nx migrate latest` to run migration scripts instead
